### PR TITLE
Add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,51 @@
-sudo: false
+sudo: required
 language: erlang
 notifications:
   email: false
 
 otp_release:
-  - 18.0
-  - 18.3
-  - 19.0
-  - 19.3
-  - 20.0
-  - 20.3
   - 21.0
   - 21.3
   - 22.0
   - 22.3
+
+env:
+  global:
+    - DOCKER_COMPOSE_VERSION: 1.25.4
+
+services:
+  - docker
+
+before_install:
+  # Upgrade Docker Compose.
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+  # Upgrade Docker.
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 install:
   - wget https://s3.amazonaws.com/rebar3/rebar3
   - chmod +x rebar3
   - export PATH=$PWD:$PATH
 
+before_script:
+  - cd $TRAVIS_BUILD_DIR
+  - docker-compose up -d
+  - cp config/sys.config.template config/sys.config
+  - sleep 15
+  - docker ps
+
 script:
   - rebar3 clean
   - rebar3 get-deps
-  - rebar3 eunit
   - rebar3 ct
   - rebar3 compile
+
+after_script:
+  - docker-compose down
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+
+#authors: [Alpha Umaru Shaw, Stanislav Sabudaye]
+
 sudo: required
 language: erlang
 notifications:

--- a/config/test_sys.config
+++ b/config/test_sys.config
@@ -1,0 +1,9 @@
+[
+  {pulserl, [
+    {autostart, true}
+    , {connect_timeout_ms, 30000}
+    , {max_connections_per_broker, 1}
+    , {socket_options, [{nodelay, true}]}
+    , {service_url, <<"pulsar://localhost:6650">>}
+  ]}
+].

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.2'
+
+services:
+
+  pulsar:
+    image: apachepulsar/pulsar:2.5.2
+    ports:
+      - "6650:6650"
+    networks:
+      - pulsar
+    environment:
+      - PULSAR_MEM=" -Xms512m -Xmx512m -XX:MaxDirectMemorySize=1g"
+    command: >
+      /bin/bash -c
+      "bin/apply-config-from-env.py ../../pulsar/conf/standalone.conf
+      && bin/pulsar standalone"
+
+networks:
+  pulsar:
+    driver: bridge

--- a/rebar.config
+++ b/rebar.config
@@ -9,3 +9,10 @@
   {config, "config/sys.config"},
   {apps, [pulserl]}
 ]}.
+
+{ct_opts, [{sys_config, ["config/test_sys.config"]}]}.
+
+{eunit_opts, [verbose, {skip_deps, true}]}.
+{eunit_exclude_deps, true}.
+{cover_enabled, true}.
+{cover_opts, [verbose]}.

--- a/test/consumer_SUITE.erl
+++ b/test/consumer_SUITE.erl
@@ -1,5 +1,5 @@
 %%%-------------------------------------------------------------------
-%%% @author Alpha Umaru Shaw <shawalpha5@gmail.com>
+%%% @author Alpha Umaru Shaw <shawalpha5@gmail.com>, 
 %%% @doc
 %%%
 %%% @end
@@ -7,7 +7,10 @@
 %%% Copyright: (C) 2020
 %%%-------------------------------------------------------------------
 -module(consumer_SUITE).
+
 -author("Alpha Umaru Shaw").
+-author("Stanislav Sabudaye").
+
 -export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
 -export([receive_message_test/1, seek_test/1]).
 -include_lib("common_test/include/ct.hrl").

--- a/test/consumer_SUITE.erl
+++ b/test/consumer_SUITE.erl
@@ -8,6 +8,62 @@
 %%%-------------------------------------------------------------------
 -module(consumer_SUITE).
 -author("Alpha Umaru Shaw").
+-export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
+-export([receive_message_test/1, seek_test/1]).
+-include_lib("common_test/include/ct.hrl").
+-include("pulserl.hrl").
 
-%% API
--export([]).
+% Common Test API
+-spec suite() -> term().
+suite() ->
+  [{timetrap, {seconds, 20}}].
+
+-spec init_per_suite(term()) -> term().
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(pulserl),
+  Config.
+
+-spec end_per_suite(term()) -> term().
+end_per_suite(_Config) ->
+  application:stop(pulserl),
+  ok.
+
+-spec groups() -> term().
+groups() ->
+  [].
+
+-spec all() -> term().
+all() ->
+  [receive_message_test, seek_test].
+
+-spec receive_message_test(term()) -> ok.
+receive_message_test(_Config) ->
+  Message = <<"message">>,
+  Topic = topic_utils:parse("test-topic"),
+  {ok, Pid} = pulserl_consumer:create(Topic, []),
+  produce_after(Topic, Message, 1),
+  do_receive_message(Pid, Message),
+  ok.
+
+produce_after(Topic, Message, Seconds) ->
+  spawn(fun() ->
+    timer:sleep(Seconds * 1000),
+    pulserl:produce(Topic, Message)
+  end).
+
+do_receive_message(Pid, Message) ->
+  case pulserl_consumer:receive_message(Pid) of
+    #consMessage{value = Message} = ConsumerMsg ->
+      _ = pulserl:ack(ConsumerMsg);
+    {error, _} = Error ->
+      error(Error);
+    _ ->
+      do_receive_message(Pid, Message)
+  end.
+
+-spec seek_test(term()) -> ok.
+seek_test(_Config) ->
+  Topic = topic_utils:parse("test-topic"),
+  {ok, Pid} = pulserl_consumer:create(Topic, []),
+  ok = pulserl_consumer:seek(Pid, 2000),
+  ok.

--- a/test/producer_SUITE.erl
+++ b/test/producer_SUITE.erl
@@ -9,5 +9,44 @@
 -module(producer_SUITE).
 -author("Alpha Umaru Shaw").
 
-%% API
--export([]).
+-export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
+-export([new_message_test/1, send_test/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include("pulserl.hrl").
+
+% Common Test API
+-spec suite() -> term().
+suite() ->
+  [{timetrap, {seconds, 20}}].
+
+-spec init_per_suite(term()) -> term().
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(pulserl),
+  Config.
+
+-spec end_per_suite(term()) -> term().
+end_per_suite(_Config) ->
+  application:stop(pulserl),
+  ok.
+
+-spec groups() -> term().
+groups() ->
+  [].
+
+-spec all() -> term().
+all() ->
+  [new_message_test, send_test].
+
+-spec new_message_test(term()) -> ok.
+new_message_test(_Config) ->
+  #prodMessage{value = <<"test message">>} = pulserl_producer:new_message("test message"),
+  ok.
+
+-spec send_test(term()) -> ok.
+send_test(_Config) ->
+  Message = pulserl_producer:new_message("test message"),
+  Topic = topic_utils:parse("test-topic"),
+  {ok, Pid} = pulserl_producer:create(Topic, []),
+  #messageId{} = pulserl_producer:sync_send(Pid, Message, ?UNDEF),
+  ok.

--- a/test/producer_SUITE.erl
+++ b/test/producer_SUITE.erl
@@ -8,6 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(producer_SUITE).
 -author("Alpha Umaru Shaw").
+-author("Stanislav Sabudaye").
 
 -export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
 -export([new_message_test/1, send_test/1]).

--- a/test/pulserl_SUITE.erl
+++ b/test/pulserl_SUITE.erl
@@ -1,5 +1,7 @@
 -module(pulserl_SUITE).
 
+-author("Stanislav Sabudaye").
+
 -export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
 -export([pulserl_produce_consume_test/1]).
 

--- a/test/pulserl_SUITE.erl
+++ b/test/pulserl_SUITE.erl
@@ -1,0 +1,52 @@
+-module(pulserl_SUITE).
+
+-export([suite/0, init_per_suite/1, end_per_suite/1, groups/0, all/0]).
+-export([pulserl_produce_consume_test/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include("pulserl.hrl").
+
+% Common Test API
+-spec suite() -> term().
+suite() ->
+  [{timetrap, {seconds, 20}}].
+
+-spec init_per_suite(term()) -> term().
+init_per_suite(Config) ->
+  {ok, _} = application:ensure_all_started(pulserl),
+  Config.
+
+-spec end_per_suite(term()) -> term().
+end_per_suite(_Config) ->
+  application:stop(pulserl),
+  ok.
+
+-spec groups() -> term().
+groups() ->
+  [].
+
+-spec all() -> term().
+all() ->
+  [pulserl_produce_consume_test].
+
+-spec pulserl_produce_consume_test(term()) -> ok.
+pulserl_produce_consume_test(_Config) ->
+  produce_after("test-topic", <<"test message">>, 1),
+  do_consume("test-topic", <<"test message">>),
+  ok.
+
+produce_after(Topic, Message, Seconds) ->
+  spawn(fun() ->
+    timer:sleep(Seconds * 1000),
+    pulserl:produce(Topic, Message)
+  end).
+
+do_consume(Topic, Message) ->
+  case pulserl:consume(Topic) of
+    #consMessage{value = Message} = ConsumerMsg ->
+      _ = pulserl:ack(ConsumerMsg);
+    {error, _} = Error ->
+      error(Error);
+    _ ->
+      do_consume(Topic, Message)
+  end.


### PR DESCRIPTION
Hi @alphashaw 

I added some tests covering basic functionality with pulsar working inside the docker image.
Also configured Travis to run it all.

However there were few issues with older Erlang versions related to `string:trim/1` (was introduced in OTP 20) or `uri_string:parse/1` (was introduced in OTP 21) used in `pulserl_utils` module.
Those issues can be observed here https://travis-ci.org/github/sabudaye/pulserl/builds/706086587
Another thing is that Travis only builds 5 versions in parallel by default, other 4 are waiting, that's slows down the build.
So I took a responsibility to remove OTP versions older then 21 from building.

Also I fixed Pulsar to version 2,5.2 in docker-compose, because 2.6.0 (latest) seems to be broken, it doesn't start.