### PR TITLE
Fix typo in pulser:start_consumer

### DIFF
--- a/src/pulserl.erl
+++ b/src/pulserl.erl
@@ -41,7 +41,7 @@ start_client(ServiceUrl, ClientConfig) ->
 %% -------------------------------------------------------------
 start_consumer(Topic) ->
   Options = pulserl_app:def_consumer_options(),
-  start_producer(Topic, Options).
+  start_consumer(Topic, Options).
 
 %%-----------------------------------------------------------------
 %% @doc Starts a consumer using the specified topic and options


### PR DESCRIPTION
I think I found a typo. Got a bit surprised trying to consume messages with consumer started by `pulserl:start_consumer`.